### PR TITLE
[승진][sprint 3] appspec.yml수정(배포 후 수행할 작업) + Ddareungi_config 디렉토리 추가

### DIFF
--- a/Ddareungi_config/after_install.sh
+++ b/Ddareungi_config/after_install.sh
@@ -1,0 +1,1 @@
+python3 /src/kafka-producer/Ddareungi_config/deploy.py

--- a/Ddareungi_config/depoly.py
+++ b/Ddareungi_config/depoly.py
@@ -1,9 +1,8 @@
 import subprocess
 
 def run_producer():
-    """producer.py를 백그라운드에서 실행하고 로그를 파일로 저장합니다."""
-    """  스크립트 실행 중 발생하는 모든 표준 출력과 표준 오류 메시지가 /src/kafka-producer/producer.log 파일에 기록 """
-    command = "nohup python /src/kafka-producer/producer.py > /src/kafka-producer/producer.log 2>&1 &"
+    """ subprocess.run 함수의 check=True 옵션은 명령어 실행이 실패할 경우 CalledProcessError 예외를 발생시키므로 스크립트가 예외 처리"""
+    command = "python /src/kafka-producer/producer.py"
     subprocess.run(command, shell=True, check=True)
 
 if __name__ == '__main__':

--- a/Ddareungi_config/depoly.py
+++ b/Ddareungi_config/depoly.py
@@ -1,0 +1,11 @@
+import subprocess
+
+def run_producer():
+    """producer.py를 백그라운드에서 실행하고 로그를 파일로 저장합니다."""
+    """  스크립트 실행 중 발생하는 모든 표준 출력과 표준 오류 메시지가 /src/kafka-producer/producer.log 파일에 기록 """
+    command = "nohup python /src/kafka-producer/producer.py > /src/kafka-producer/producer.log 2>&1 &"
+    subprocess.run(command, shell=True, check=True)
+
+if __name__ == '__main__':
+    run_producer()
+

--- a/appspec.yml
+++ b/appspec.yml
@@ -30,15 +30,12 @@ permissions:
     mode: 755      # 파일의 권한(mode)을 지정합니다. 여기서는 rwxr-xr-x로 설정됩니다.
 
 # hooks를 통해 배포 전후에 수행할 동작을 정의할 수 있습니다.
-# 예를 들어, before_install, after_install, application_start 등의 후크를 사용할 수 있습니다.
+# 예를 들어, before_install, after_install.sh, application_start 등의 후크를 사용할 수 있습니다.
 # 현재는 후크(hooks)에 대한 정의가 없습니다.
-'''
-hooks:
-  # 배포 전 수행할 작업을 정의합니다.
-  before_install:
-    - location: scripts/before_install.sh
 
+hooks:
   # 배포 후 수행할 작업을 정의합니다.
   after_install:
-    - location: scripts/after_install.sh
-'''
+    - location: Ddareungi_config/after_install.sh
+      timeout: 300  # Timeout in seconds
+      runas: root  # 스크립트를 실행할 사용자 지정


### PR DESCRIPTION

ㅁ 현재 상황

1) api_key.bin파일에서 저장된 API키에 대한 값을 가져와서
.env 확장자 파일을 쓰지 않음.

2) .env 확장자 파일을 쓸려면 dotenv 패키지를 설치해야하는데, 
pip 버전 충돌이 일어나서 쓸 수 가없음.

3) 결론적으로 API키에 대한 값을 저장한  api_key.bin 파일을 불러들이는 기능나열하자면,
-----------------------------------------------------------------
ㅁ depoly.py 
1. producer.py 스크립트는 서울 열린 데이터 광장 API로부터 따릉이 정보를 가져와 Kafka에 전송하는 역할. 스크립트는 성공적으로 데이터를 받아 처리하고 Kafka로 보낼 때마다 로그에 이를 기록.

2. 성공적인 Kafka 전송: 각 레코드에 대해 'Sent data to Kafka'와 함께 따릉이 스테이션 데이터가 기록.
오류 메시지: API에 연결할 수 없을 때와 같은 예외 상황이 발생하면 오류 메시지가 기록. 이 메시지는 문제를 진단하고 해결하는 데 도움됨.

4. 실행 후 확인 사항:
스크립트가 예상대로 동작하고 있는지 확인하기 위해 producer.log 파일을 주기적으로 확인.

예를 들어
`Sent data to Kafka: {'rackTotCnt': '15', 'stationName': '서울역 2번 출구 앞', 'parkingBikeTotCnt': '5', 'shared': '33', 'stationLatitude': '37.556000', 'stationLongitude': '126.972000', 'stationId': '1001', 'timestamp': '2024-05-24 15:30:21'}
Sent data to Kafka: {'rackTotCnt': '12', 'stationName': '시청역 1번 출구 앞', 'parkingBikeTotCnt': '4', 'shared': '25', 'stationLatitude': '37.564000', 'stationLongitude': '126.977000', 'stationId': '1002', 'timestamp': '2024-05-24 15:31:22'}
Error: HTTPConnectionPool(host='openapi.seoul.go.kr', port=8088): Max retries exceeded with url: /api_key/json/bikeList/1/1000/ (Caused by NewConnectionError('<urllib3.connection.HTTPConnection object at 0x7f9364c2bf40>: Failed to establish a new connection: [Errno 111] Connection refused'))`
------------------------------------------------------------------
ㅁ api_key.binㅇ 파일은 어디서 사용되는가?

1. API를 이용해서 데이터  잘 가져오는지에 대한 테스트코드 쓰임.
(tests/test.py + seoul_bike_api.py)

2. appsepc.yml 파일에서  스크립트를 배포 후 실행하도록 설정한 depoly.py에서
쓰임. (after_install 후크를 사용하여 depoly.py를 호출함.)
---------------------------------------------------------------